### PR TITLE
Fix snprintf() overflow handling

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -49,18 +49,24 @@ int open_log(char *filename)
 char *add_log(char *msg, char *mp, char *format, ...)
 {
     va_list ap_msg;
+    int rc;
 
-    if(!mp || mp - msg < 0 || mp - msg > MAX_MSG_SIZE)
+    if(!mp || mp - msg < 0 || mp - msg >= MAX_MSG_SIZE)
         return(NULL);
 
     va_start(ap_msg, format);
-    mp += vsnprintf(mp, MAX_MSG_SIZE - (mp - msg), format, ap_msg);
+    rc = vsnprintf(mp, MAX_MSG_SIZE - (mp - msg), format, ap_msg);
     va_end(ap_msg);
 
-    if(mp - msg > MAX_MSG_SIZE) {
+    if(rc < 0) {
+        rec_log("error: snprintf failed");
+        return(NULL);
+    }
+    if(rc >= MAX_MSG_SIZE - (mp - msg)) {
         rec_log("error: message truncated");
         return(NULL);
     }
+    mp += rc;
 
     return(mp);
 }

--- a/src/nield.h
+++ b/src/nield.h
@@ -732,4 +732,11 @@ void debug_tca_csum_tm(int lev, struct rtattr *csum, const char *name);
 void debug_tca_csum_parms(int lev, struct rtattr *csum, const char *name);
 void conv_tca_csum_update_flags(int flags, char *flags_list, int len, unsigned char debug);
 #endif
+
+#define APPEND_SNPRINTF(RC, P, LEN, ...) do {   \
+    int RC = snprintf(P, LEN, __VA_ARGS__);     \
+    RC = RC < 0 ? 0 : RC >= LEN ? LEN : RC;     \
+    P += RC;                                    \
+    LEN -= RC;                                  \
+} while(0)
 #endif /* _NIELD_ */

--- a/src/rta.c
+++ b/src/rta.c
@@ -346,9 +346,8 @@ int arphrd_ntop(unsigned short type, struct rtattr *ifla, char *dst, int dstlen)
     }
 
     for(i = 0; i < srclen; i++)
-        if(p - dst < dstlen)
-            p += snprintf(p, dstlen - strlen(dst), "%02x%s",
-                src[i], (i + 1 == srclen) ? "" : ":");
+        APPEND_SNPRINTF(rc, p, dstlen, "%02x%s",
+            src[i], (i + 1 == srclen) ? "" : ":");
 
     return(0);
 }

--- a/src/tcmsg_filter.c
+++ b/src/tcmsg_filter.c
@@ -199,17 +199,17 @@ int parse_tca_mask(char *msg, char **mp, struct rtattr *tca)
 void parse_u32_handle(char *p, int len, unsigned handle)
 {
     if(TC_U32_HTID(handle))
-        p += snprintf(p, len, "%x", TC_U32_HTID(handle)>>20);
+        APPEND_SNPRINTF(rc, p, len, "%x", TC_U32_HTID(handle)>>20);
 
-    p += snprintf(p, len, ":");
+    APPEND_SNPRINTF(rc, p, len, ":");
 
     if(TC_U32_HASH(handle))
-        p += snprintf(p, len, "%x", TC_U32_HASH(handle));
+        APPEND_SNPRINTF(rc, p, len, "%x", TC_U32_HASH(handle));
 
-    p += snprintf(p, len, ":");
+    APPEND_SNPRINTF(rc, p, len, ":");
 
     if(TC_U32_NODE(handle))
-        p += snprintf(p, len, "%x", TC_U32_NODE(handle));
+        APPEND_SNPRINTF(rc, p, len, "%x", TC_U32_NODE(handle));
 }
 
 /*

--- a/src/tcmsg_qdisc_prio.c
+++ b/src/tcmsg_qdisc_prio.c
@@ -60,14 +60,14 @@ void debug_tca_options_prio(int lev, struct rtattr *tca, const char *name)
 
     for(i = 0; i < TC_PRIO_MAX + 1; i++) {
         if(i == TC_PRIO_MAX)
-            p += snprintf(p, len - strlen(prio), "%d ", qopt->priomap[i]);
+            APPEND_SNPRINTF(rc, p, len, "%d ", qopt->priomap[i]);
         else
-            p += snprintf(p, len - strlen(prio), "%d-", qopt->priomap[i]);
-        if(len < p - prio) {
-            rec_dbg(lev, "%s(%hu): -- priomap too long --",
+            APPEND_SNPRINTF(rc, p, len, "%d-", qopt->priomap[i]);
+    }
+    if (p - prio == sizeof(prio)) {
+        rec_dbg(lev, "%s(%hu): -- priomap too long --",
                 name, RTA_ALIGN(tca->rta_len));
-            return;
-        }
+        return;
     }
 
     rec_dbg(lev, "%s(%hu):", name, RTA_ALIGN(tca->rta_len));


### PR DESCRIPTION
When error happens or formatted string would overflow buffer, snprintf returns negative value or value larger than buffer size.
If you add this value to pointer without checking range, [bad things will happen](http://permalink.gmane.org/gmane.comp.security.oss.general/18815).
Also fixed some related off-by-one errors (snprintf(p, len,...) == len).
Disclaimer: As I don't use nield, compile-tested only. I also have not checked if any of those are exploitable.